### PR TITLE
Wells Fargo and First Trust added to Fintech

### DIFF
--- a/Fintech
+++ b/Fintech
@@ -4,4 +4,5 @@ Rohinhood
 Bugfix
 Chase
 BOA
-main
+Wellsfargo
+First Trust


### PR DESCRIPTION
Wells Fargo and First Trust added to Fintech